### PR TITLE
chore: bump platform-expressif32 to 55.03.35

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:ESP32-C6-DevKitM-1]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 framework = arduino
 board = esp32-c6-devkitm-1
 monitor_speed = 115200


### PR DESCRIPTION
Bumps platform-expressif32 to version 55.03.35 (latest as of 2026/01/13)

The prior version produces an error due to esp_idf_size being invoked with invalid arguments by PlatformIO.