### PR TITLE
wifi onboarding updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -708,6 +708,8 @@ bool wifiSmart() {
          // try to connect wifi if ble data is set
          if (wifiSettings.bleSSID.length() > 1 && wifiSettings.blePASS.length() > 1) {
             Serial.println("[NETWORK] got all BLE, try to connect with data");
+            wifiSettings.wifiIsConnected = true;
+            wifiConnectedCharacteristic->setValue(wifiSettings.wifiIsConnected);
             WiFi.begin(wifiSettings.bleSSID.c_str(), wifiSettings.blePASS.c_str());
             WiFi.waitForConnectResult(10000);
             if (WiFi.status() == WL_CONNECTED) {
@@ -716,6 +718,8 @@ bool wifiSmart() {
             }
             WiFi.disconnect(true);
             wifiSettings.blePASS = "";
+            wifiSettings.wifiIsConnected = false;
+            wifiConnectedCharacteristic->setValue(wifiSettings.wifiIsConnected);
             // break;
          }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,7 +602,7 @@ bool wifiSmart() {
 #endif
 
    if (isWifi == false && isTestMode == false && doReset == false) {
-      BleInit(CLIENT_ID, true);
+      // BleInit(CLIENT_ID, true);
       powerSupplyDisplay(true);
       wifiTimeout = 5000UL;
       updateDisplayAsync("wifiactivate");
@@ -619,9 +619,6 @@ bool wifiSmart() {
          Serial.println("[NETWORK] Stop connect because no wifi set");
          break;
       }
-      if (waitDisplayComplete(true) && i >= 1 && isWifi == false) {
-         BleInit(CLIENT_ID, true);  // needs to wait for display, otherwise scan no results
-      }
       WiFi.begin(wifiSettings.ssid.c_str(), wifiSettings.pss.c_str());
       WiFi.waitForConnectResult(wifiTimeout);
       if (WiFi.status() == WL_CONNECTED) {
@@ -630,7 +627,8 @@ bool wifiSmart() {
       WiFi.disconnect(true);
 
       delay(1000);
-      if (!isWifi && i >= 1 && waitDisplayComplete(true)) {
+      // if (!isWifi && i >= 1 && waitDisplayComplete(true)) {
+      if (!isWifi && i >= 1) {
          BleInit(CLIENT_ID, true);
          Serial.println("[NETWORK] stop search because default wifi");  // skip the intense connect if default wifi
          break;
@@ -677,6 +675,7 @@ bool wifiSmart() {
       Serial.println("[NETWORK] wait for wifi via ble...");
       int countAttempt = 0;
       int failedCounter = 0;
+      BleInit(CLIENT_ID, true);
       while (true) {
          if (!isBleClientConnected) {
             countAttempt++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -683,7 +683,7 @@ bool wifiSmart() {
             Serial.print(".");
          }
          delay(250);
-         if (countAttempt % (4 * 10) == 0) {
+         if (countAttempt % (4 * 10) == 0 && !isBleClientConnected) {
             // this gets triggered every 10 seconds on provisioning
             Serial.printf("[NETWORK] Provisioning attempt %d/%d \n", countAttempt, (WIFI_INIT_TIME * 4));
          }
@@ -710,6 +710,12 @@ bool wifiSmart() {
             Serial.println("[NETWORK] got all BLE, try to connect with data");
             WiFi.begin(wifiSettings.bleSSID.c_str(), wifiSettings.blePASS.c_str());
             WiFi.waitForConnectResult(10000);
+            if (WiFi.status() == WL_CONNECTED) {
+               Serial.println("[NETWORK] Wifi got IP (softAP)");
+               break;
+            }
+            WiFi.disconnect(true);
+            wifiSettings.blePASS = "";
             // break;
          }
       }


### PR DESCRIPTION
This pull request makes several adjustments to the WiFi and BLE (Bluetooth Low Energy) initialization and connection logic in the `wifiSmart()` function within `src/main.cpp`. The main goals are to refine when BLE is initialized, improve connection handling, and ensure more accurate status reporting during WiFi provisioning. Below are the most important changes grouped by theme:

**BLE Initialization and Provisioning Logic:**

* Commented out or removed redundant calls to `BleInit(CLIENT_ID, true)` at the start of WiFi activation and after certain display events, preventing unnecessary BLE initialization when not required. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L605-R605) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L622-L624)
* Moved and simplified BLE initialization during WiFi provisioning, ensuring that `BleInit` is called only when needed (e.g., after certain failed WiFi attempts or during BLE provisioning). [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L633-R631) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R678-R685)

**WiFi Connection Handling and Status Reporting:**

* Improved the WiFi connection attempt logic by immediately updating the `wifiIsConnected` status and synchronizing it with the BLE characteristic before and after connection attempts using BLE-provided credentials. This ensures accurate status reporting to BLE clients during provisioning.
* Added logic to clear sensitive BLE-provided credentials and reset the connection status if the WiFi connection fails, enhancing security and robustness.
* Adjusted the provisioning attempt logging to only print status messages when not already connected to a BLE client, reducing log noise.